### PR TITLE
Add detailed README with trading overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
 # EloPairs
+
+EloPairs is an experimental pairs trading project that combines traditional spread trading rules with an **Elo rating** signal and reinforcement learning (RL). The repository demonstrates how to engineer features, generate trade logs, and train RL agents to decide whether to enter a given trade.
+
+## Feature Engineering
+
+1. **Pair Spreads**  
+   For symbols $A$ and $B$ the log prices are $\log P_A$ and $\log P_B$. We estimate a hedge ratio $\beta$ using OLS:
+   \[
+   \log P_A(t) = \alpha + \beta \cdot \log P_B(t) + \varepsilon_t.
+   \]
+   The spread is then
+   \[
+   s_t = \log P_A(t) - \beta\,\log P_B(t).
+   \]
+   A rolling mean and standard deviation of $s_t$ yield the Z-score
+   \[
+   z_t = \frac{s_t - \mu_t}{\sigma_t}.
+   \]
+2. **Elo Ratings**  
+   Each stock receives an Elo rating that updates according to relative returns $r_A$ and $r_B$ at time $t$:
+   \[
+   R_A^{\text{new}} = R_A + K \left(S_A - E_A\right),\qquad
+   R_B^{\text{new}} = R_B + K \left(1-S_A - (1-E_A)\right),
+   \]
+   where $E_A = \frac{1}{1 + 10^{(R_B-R_A)/400}}$ and $S_A$ encodes which stock outperformed. The difference $R_A - R_B$ is used as an additional momentum signal.
+
+The script `build_dataset.py` loads price data (`NSE_PFC_EQ_candlestick_data.csv` and `NSE_RECLTD_EQ_candlestick_data.csv`), computes these features, and writes `PFC_RECLTD_feature_set.csv`.
+
+## Trading Logic
+
+`tradelog.py` reads the engineered features and creates a trade log. Positions open when:
+
+- $z_t \geq 1.5$ **and** the normalized Elo difference decreases by at least 0.38 → short the spread.
+- $z_t \leq -1.5$ **and** the normalized Elo difference increases by at least 0.38 → long the spread.
+
+Trades close when the opposite conditions occur. PnL is calculated with a position size that can scale down when a market turbulence index is high. The resulting trades are assembled into `trade_log_df` and an equity curve can be plotted.
+
+## Reinforcement Learning
+
+Two environments (`dqltradeLog.py` and `ppo_trading_agent.py`) expose each trade opportunity as a step with action space `{0=skip, 1=enter}`. Rewards correspond to realized trade PnL. The included examples train:
+
+- A Deep Q-Network (DQN) agent (`trainingdwnonTradelog.py`).
+- A Proximal Policy Optimization (PPO) agent (`ppo_trading_agent.py`).
+
+Both rely on [Stable-Baselines3](https://github.com/DLR-RM/stable-baselines3). Successful training requires the dependencies listed below.
+
+## File Overview
+
+- `build_dataset.py` – construct feature set with spreads, z-scores and Elo ratings.
+- `turbulence_calc.py` – compute a simple turbulence index from index returns.
+- `tradelog.py` – generate entry/exit signals and PnL, producing `trade_log_df`.
+- `dqltradeLog.py` – minimal RL environment for DQN.
+- `trainingdwnonTradelog.py` – trains the DQN agent.
+- `ppo_trading_agent.py` – example PPO training script.
+- `elodiff_graph.py` – plot z-scores and Elo differences.
+
+CSV files under the repo provide sample candlestick data for the two stocks and the NIFTY index.
+
+## Requirements
+
+The project uses Python 3 with packages such as `pandas`, `numpy`, `gymnasium`, `stable-baselines3`, `statsmodels`, and `plotly`. Install via:
+
+```bash
+pip install pandas numpy gymnasium stable-baselines3 statsmodels plotly
+```
+
+## Quick Start
+
+1. Run `build_dataset.py` to create the feature CSV.
+2. Execute `tradelog.py` to produce the trade log and view an equity curve.
+3. Optionally train a RL agent using `trainingdwnonTradelog.py` or `ppo_trading_agent.py`.
+
+This repository serves as a sandbox for exploring Elo-based pairs trading and RL-driven trade selection. Extensive backtesting and risk management are needed before considering live deployment.
+

--- a/ppo_trading_agent.py
+++ b/ppo_trading_agent.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pandas as pd
+import gymnasium as gym
+from gymnasium import spaces
+
+# The trade_log_df DataFrame is generated in tradelog.py
+from tradelog import trade_log_df
+
+class TradingEnv(gym.Env):
+    """Simple environment where the agent decides to take or skip each trade."""
+
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self, trade_log_df: pd.DataFrame, initial_capital: float = 10_000_000):
+        super().__init__()
+        self.trade_log = trade_log_df.reset_index(drop=True)
+        self.initial_capital = initial_capital
+        self.capital = initial_capital
+        self.current_trade = 0
+
+        # Action: 0 = Skip, 1 = Enter trade
+        self.action_space = spaces.Discrete(2)
+
+        # Observation: basic features from the trade log
+        self.observation_space = spaces.Box(low=-np.inf, high=np.inf, shape=(5,), dtype=np.float32)
+
+    def _get_observation(self) -> np.ndarray:
+        if self.current_trade < len(self.trade_log):
+            row = self.trade_log.iloc[self.current_trade]
+            obs = np.array([
+                row.get("Entry Z-Score", 0.0),
+                row.get("Entry Normalized Elo Diff", 0.0),
+                row.get("Elo Change at Entry", 0.0),
+                row.get("Market Turbulence at Entry", 0.0),
+                row.get("Position Multiplier", 1.0),
+            ], dtype=np.float32)
+        else:
+            obs = np.zeros(self.observation_space.shape, dtype=np.float32)
+        return obs
+
+    def reset(self, seed=None, options=None):
+        super().reset(seed=seed)
+        self.current_trade = 0
+        self.capital = self.initial_capital
+        return self._get_observation(), {}
+
+    def step(self, action: int):
+        if self.current_trade >= len(self.trade_log):
+            return self._get_observation(), 0.0, True, False, {}
+
+        trade = self.trade_log.iloc[self.current_trade]
+        reward = 0.0
+        if action == 1:
+            reward = float(trade["PnL"])
+            self.capital += reward
+
+        self.current_trade += 1
+        obs = self._get_observation()
+        terminated = self.current_trade >= len(self.trade_log)
+        return obs, reward, terminated, False, {}
+
+    def render(self, mode="human"):
+        print(f"Trade {self.current_trade} | Capital: {self.capital:.2f}")
+
+if __name__ == "__main__":
+    # Training with PPO if stable-baselines3 is available
+    try:
+        from stable_baselines3 import PPO
+        from stable_baselines3.common.env_checker import check_env
+
+        env = TradingEnv(trade_log_df)
+        check_env(env, warn=True)
+        model = PPO("MlpPolicy", env, verbose=1, learning_rate=3e-4)
+        model.learn(total_timesteps=1_000_000)
+        model.save("ppo_trading_model")
+
+        # Evaluate the trained agent
+        obs, _ = env.reset()
+        done = False
+        total_reward = 0.0
+        while not done:
+            action, _ = model.predict(obs, deterministic=True)
+            obs, reward, done, _, _ = env.step(int(action))
+            total_reward += reward
+        print("Evaluation reward:", total_reward)
+    except Exception as e:
+        print("Training could not be completed:", e)


### PR DESCRIPTION
## Summary
- explain project components and pair trading logic in README
- include equations for spread z-score and Elo updates

## Testing
- `python -m py_compile ppo_trading_agent.py`
- `python ppo_trading_agent.py` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_684a9c5887b08331aec55caf9fefd903